### PR TITLE
Did a bit of cleanup

### DIFF
--- a/usb_console.fs
+++ b/usb_console.fs
@@ -21,8 +21,6 @@
 
 compile-to-flash
 
-marker remove-usb-console
-
 begin-module usb
 
   console import
@@ -464,3 +462,5 @@ begin-module usb
   ;
 
 end-module
+
+compile-to-ram

--- a/usb_constants.fs
+++ b/usb_constants.fs
@@ -21,8 +21,6 @@
 
 compile-to-flash
 
-marker remove-usb-constants
-
 begin-module usb-constants
 
   false constant debug?
@@ -294,3 +292,5 @@ begin-module usb-constants
   USB_DPRAM_Base $180 + constant USB_BUFFER_Base
 
 end-module
+
+compile-to-ram

--- a/usb_core.fs
+++ b/usb_core.fs
@@ -21,8 +21,6 @@
 
 compile-to-flash
 
-marker remove-usb-core
-
 begin-module usb-core
 
   armv6m import
@@ -171,7 +169,6 @@ begin-module usb-core
       field: dpram-address        \ DPRAM address in Pico hardware
       field: next-pid             \ Endpoint next PID (0 for PID0 or 8192 for PID1)
       field: buffer-control       \ Endpoint buffer control register address
-      field: buffer-dispatch      \ Endpoint buffer dispatch used by send packet
       field: endpoint-control     \ Endpoint control register address
       field: transfer-type        \ Endpoint transfer type (Control, Bulk, Interrupt)
       field: transfer-bytes       \ Endpoint transfer bytes (To send or received)
@@ -180,8 +177,6 @@ begin-module usb-core
       field: total-bytes          \ Total transfer bytes (Multipacket)
       field: source-address       \ Source data address (Multipacket transmit)
       field: callback-handler     \ Callback handler for CDC set line coding 
-      field: queue-busy?          \ Is queue currently holding or transferring data ?
-      field: queue-long?          \ Does queue have sufficient capacity for another packet ?
 
     \ there is no endpoint control register for EP0, interrupt enable for EP0 comes from SIE_CTRL
 
@@ -1219,3 +1214,5 @@ begin-module usb-core
   ;
 
 end-module
+
+compile-to-ram


### PR DESCRIPTION
A removed a bit of unneeded code, including the `marker`s (because it is working now, aside from that the pesky RP2350 zeptocom.js bug is still there when I modify zeptocom.js to use a buffer of 65535 rather than 16 bytes).